### PR TITLE
Update application.properties

### DIFF
--- a/api/src/main/resources/application.properties
+++ b/api/src/main/resources/application.properties
@@ -12,3 +12,4 @@ logging.level.org.springframework.boot.web.embedded.tomcat=INFO
 
 #H2 Database configuration
 spring.h2.console.enabled=true
+spring.jpa.hibernate.ddl-auto=none


### PR DESCRIPTION
dans mon cas (spring boot 2.6.1- intelliJ - java 15) il fallait ajouter cette configuration pour permettre à la base H2 d'être rechargée à chaque lancement de test par exemple sinon le programme se lançait mais les insert en base de données n'étaient effectués qu'au premier lancement.